### PR TITLE
Fix typo Update SUMMARY.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,7 +37,7 @@
     - [Sentry](advanced/sentry.md)
     - [Downloader](advanced/downloader.md)
     - [TLS Authentication](advanced/tls-authentication.md)
-    - [Perfomance Tricks](advanced/performance.md)
+    - [Performance Tricks](advanced/performance.md)
 
  ---
 


### PR DESCRIPTION
I fixed a typo in the SUMMARY.md file, correcting the word "Perfomance" to "Performance" in the link text.

Specific Change:
Before:
[Perfomance Tricks](advanced/performance.md)
After:
[Performance Tricks](advanced/performance.md)
This update ensures proper spelling, enhancing the professionalism and clarity of the documentation.