### PR TITLE
chore: update default prune in basic usage to full

### DIFF
--- a/src/basic-usage.md
+++ b/src/basic-usage.md
@@ -20,8 +20,8 @@ The default Consensus Layer utilized is [Caplin](./advanced/caplin.md), the Erig
     --datadir=<your_data_dir>
     ```
 
-* Based on the [type of node](basic/node.md) you want to run you can add ```--prune.mode=archive``` to run a archive node or ```--prune.mode=minimal``` for a minimal node.
-The default node is archive node.
+* Based on the [type of node](basic/node.md) you want to run you can add ```--prune.mode=archive``` to run a archive node, ```--prune.mode=full``` for a full node or ```--prune.mode=minimal``` for a minimal node.
+The default node is full node.
 * ```--chain=mainnet```, add the flag `--chain=sepolia` for Sepolia testnet or `--chain=holesky` for Holesky testnet.
 * ```--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool``` to use RPC and e.g. be able to connect your [wallet](basic/wallet.md).
 * To increase download speed add ```--torrent.download.rate=512mb``` (default is 16mb).


### PR DESCRIPTION
The basic usage page seemed to have some lingering defaults from v2. 

Added the option of the `full` and updated the doc to specify that `full` is the default. 

