### PR TITLE
250724 mdbook linkcheck

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -8,10 +8,11 @@ src = "src"
 
 [output.html]
 git-repository-url = "https://github.com/erigontech/docs"
+default-theme = "Ayu"
+preferred-dark-theme = "Ayu"
+
 [output.html.fold]
 enable = true    # whether or not to enable section folding
 level = 0         # the depth to start folding
-theme = "my-theme"
-default-theme = "Ayu"
 
 [output.linkcheck]

--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,5 @@ enable = true    # whether or not to enable section folding
 level = 0         # the depth to start folding
 theme = "my-theme"
 default-theme = "Ayu"
+
+[output.linkcheck]

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,7 +14,7 @@
         - [Build executable binaries natively for Windows](installation/build_exec_win.md)
         - [Windows Subsystem for Linux (WSL)](installation/wsl.md)
     - [Docker](installation/docker.md)
-    - [Upgrading from a previous version](installation/upgrading-md)
+    - [Upgrading from a previous version](installation/upgrading.md)
 
 - [Basic Usage](basic-usage.md)
     - [Type of Node](basic/node.md)
@@ -23,7 +23,7 @@
     - [Supported Networks](basic/networks.md)
     - [Default Ports and Firewalls](basic/ports.md)
     - [YAML/TOML Config](basic/yaml.md)
-    - [Web3 Wallet](basic/wallet)
+    - [Web3 Wallet](basic/wallet.md)
 
 - [Quick nodes](quick_nodes.md)
     - [How to run an Ethereum node](nodes/ethereum.md)

--- a/src/about/contributing.md
+++ b/src/about/contributing.md
@@ -2,7 +2,7 @@
 
  
 - [Contributing to Erigon 3](#contributing-to-erigon-3)
-- [Contributing to Documentation](#contributing-to-documentation)
+- [Contributing to Documentation](#contributing-to-this-documentation)
 
 
 ## Contributing to Erigon 3

--- a/src/advanced/JSONRPC-daemon.md
+++ b/src/advanced/JSONRPC-daemon.md
@@ -25,7 +25,7 @@ This document provides guidelines for understanding and using the various RPC me
    - This gRPC API is also accessible to users. For more information, visit the [Erigon Interfaces GitHub repository](https://github.com/erigontech/interfaces).
 
 1. **Trace Module (`trace_`)**  
-   - Erigon includes **[the `trace_` module](/advanced/JSONRPC-trace-module.md)**, which originates from OpenEthereum. This module provides additional functionality related to tracing transactions and state changes, which is valuable for advanced debugging and analysis.
+   - Erigon includes **[the `trace_` module](JSONRPC-trace-module.md)**, which originates from OpenEthereum. This module provides additional functionality related to tracing transactions and state changes, which is valuable for advanced debugging and analysis.
 
 ## More info
 

--- a/src/advanced/JSONRPC-trace-module.md
+++ b/src/advanced/JSONRPC-trace-module.md
@@ -73,7 +73,7 @@ Executes the given call and returns a number of possible traces for it.
 
 #### Parameters
 
-0. `Object` - [Transaction object](./JSONRPC.md#transactions) where `from` field is optional and `nonce` field is omitted.
+0. `Object` - [Transaction object] where `from` field is optional and `nonce` field is omitted.
 0. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 0. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 

--- a/src/advanced/bp-ext.md
+++ b/src/advanced/bp-ext.md
@@ -2,8 +2,8 @@
 
 To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighhouse and Prysm to run along with Erigon:
 
-- [Ethereum](/nodes/ethereum.md#erigon-with-prysm-as-the-external-consensus-layer)
-- [Gnosis Chain](/nodes/gnosis.md#erigon-with-lighthouse)
+- [Ethereum](../nodes/ethereum.md#erigon-with-prysm-as-the-external-consensus-layer)
+- [Gnosis Chain](../nodes/gnosis.md#erigon-with-lighthouse)
 
 Once you have Erigon and a CL client up and running, you can proceed to set up a Validator Client (VC). The VC is responsible for managing your keys and signing valid blocks.
 

--- a/src/advanced/caplin.md
+++ b/src/advanced/caplin.md
@@ -22,4 +22,4 @@ In addition, Caplin can backfill recent blobs for an op-node or other uses with 
 
 - `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
-Caplin can also be used for [block production](/advanced/bp-caplin.md), aka **staking**.
+Caplin can also be used for [block production](bp-caplin.md), aka **staking**.

--- a/src/advanced/configuring.md
+++ b/src/advanced/configuring.md
@@ -1,6 +1,6 @@
 # Configuring Erigon
 
-The Erigon 3 CLI has a wide range of flags that can be used to customize its behavior. Here's a breakdown of some of the flags, see [Options](/advanced/options.md) for the full list:
+The Erigon 3 CLI has a wide range of flags that can be used to customize its behavior. Here's a breakdown of some of the flags, see [Options](options.md) for the full list:
 
 ## Data Storage
 
@@ -23,7 +23,7 @@ The Erigon 3 CLI has a wide range of flags that can be used to customize its beh
 
 ## Pruning Presets
 
-* `--prune.mode`: Choose a pruning preset: `archive`, `full`, or `minimal` (default: `full`) see also [Type of node](/basic/node.md)
+* `--prune.mode`: Choose a pruning preset: `archive`, `full`, or `minimal` (default: `full`) see also [Type of node](../basic/node.md)
 * `--prune.distance`: Keep state history for the latest N blocks (default: everything) (default: `0`)
 * `--prune.distance.blocks`: Keep block history for the latest N blocks (default: everything) (default: `0`)
 

--- a/src/advanced/consensus_layer.md
+++ b/src/advanced/consensus_layer.md
@@ -14,14 +14,14 @@ Basically, without a CL client, the EL will never sync.
 
 **Information**
 
-By default, Erigon is configured to run with [Caplin](/advanced/caplin.md), the embedded CL.
+By default, Erigon is configured to run with [Caplin](caplin.md), the embedded CL.
 </div>
 
 ## Choosing an external CL client
 
 While Erigon runs by default with Caplin, the embedded CL, it is possible to run Erigon with any external CL. Below are some examples of how to configure Lighthouse and Prysm to run alongside Erigon:
 
-- [Ethereum](/nodes/eth_extcl.md)
-- [Gnosis Chain](/nodes/gno_extcl.md)
+- [Ethereum](../nodes/eth_extcl.md)
+- [Gnosis Chain](../nodes/gno_extcl.md)
 
 > **Important note**: When configuring a CL client, always refer to the official CL documentation for the most up-to-date and accurate configuration instructions to avoid any potential issues.

--- a/src/basic-usage.md
+++ b/src/basic-usage.md
@@ -28,7 +28,7 @@ The default node is full node.
 
 To stop the Erigon node you can use the ```CTRL+C``` command.
 
-Additional flags can be added to configure the node with several [options](/advanced/options.md).
+Additional flags can be added to configure the node with several [options](advanced/options.md).
 
 
 # Testnets

--- a/src/basic/disk-space.md
+++ b/src/basic/disk-space.md
@@ -41,4 +41,4 @@ See also [sync times](https://github.com/erigontech/erigon?tab=readme-ov-file#sy
 | Hoodi    |     16 GB    |     16 GB |  15 GB       |
 | Chiado   |     25 GB    |     18 GB |  14 GB       |
 
-See also hints on [optimizing storage](/basic/optimizing-storage.md).
+See also hints on [optimizing storage](optimizing-storage.md).

--- a/src/basic/ports.md
+++ b/src/basic/ports.md
@@ -10,7 +10,7 @@ To ensure proper P2P functionality for both the Execution and Consensus layers u
 
 ## Command-Line Switches for Network and Port Configuration
 
-Here is an extensive list of port-related options from the [options](/advanced/options.md) list:
+Here is an extensive list of port-related options from the [options](../advanced/options.md) list:
 
 ### Engine
 

--- a/src/basic/wallet.md
+++ b/src/basic/wallet.md
@@ -23,7 +23,7 @@ To configure your local Metamask wallet (browser extension):
 * Click **Add network**
 * A new browser tab will open, displaying various fields to fill out. Complete the fields with the proper information, in this example for Ethereum network:
     * **Network Name**: `Ethereum on E3` (or any name of your choice)
-    * **Chain ID**: `1` for chain ID parameter see [Supported Networks](/basic/networks.md)
+    * **Chain ID**: `1` for chain ID parameter see [Supported Networks](networks.md)
     * **New RPC URL**: `http://127.0.0.1:8545`
     * **Currency Symbol**: `ETH`
     * **Block Explorer URL**: `https://www.etherscan.io` (or any explorer of your choice)

--- a/src/faq.md
+++ b/src/faq.md
@@ -1,3 +1,0 @@
-# Frequently Asked Questions
-
-<img src="/images/WIP.png" alt="" style="display: block; margin: 0 auto;">

--- a/src/getting-started/hw-requirements.md
+++ b/src/getting-started/hw-requirements.md
@@ -6,7 +6,7 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 Additionally, SSDs may experience performance degradation when nearing full capacity.
 
-See here how you can [optimize storage](/basic/optimizing-storage.md).
+See here how you can [optimize storage](../basic/optimizing-storage.md).
 
 
 Here is the outline of the hardware requirements for running Erigon on the following networks:

--- a/src/getting-started/sw-requirements.md
+++ b/src/getting-started/sw-requirements.md
@@ -4,7 +4,7 @@ If you plan to compile Erigon from source, ensure that the following prerequisit
 
 Erigon works only from command line interface (CLI), so it is advisable to have a good confidence with basic commands.
 
-> Please note that building software from source can be complex. If you're not comfortable with technical tasks, we recommend you use other [installation](/installation.md) methods like pre-built images or Docker and skip these requirements.
+> Please note that building software from source can be complex. If you're not comfortable with technical tasks, we recommend you use other [installation](../installation.md) methods like pre-built images or Docker and skip these requirements.
 
 
 ### Git
@@ -35,4 +35,4 @@ This turns the C++ part of Erigon's code into a program your computer can run. Y
 - For **Clang** follow the instructions at [https://clang.llvm.org/get_started.html](https://clang.llvm.org/get_started.html);
 - For **GCC** (version 10 or newer): [https://gcc.gnu.org/install/index.html](https://gcc.gnu.org/install/index.html).
 
-You can now proceed with Erigon [installation](/installation.md).
+You can now proceed with Erigon [installation](../installation.md).

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -2,4 +2,4 @@
 
 In order to use Erigon, the software has to be installed first. There are several ways to install Erigon, depending on the operating system and the user's choice of installation method, e.g. using a package manager, docker container or building from source.
 
-Verify carefully that your [hardware](/getting-started/hw-requirements.md) satisfy the requirements and your machine is running the required [software](/getting-started/sw-requirements.md).
+Verify carefully that your [hardware](getting-started/hw-requirements.md) satisfy the requirements and your machine is running the required [software](getting-started/sw-requirements.md).

--- a/src/installation.md
+++ b/src/installation.md
@@ -6,12 +6,12 @@ In order to use Erigon, the software has to be installed first. There are severa
 
 _____________________________
 
-[Linux and MacOS](/installation/linux.md)
+[Linux and MacOS](installation/linux.md)
 
-[Windows](/installation/windows.md)
+[Windows](installation/windows.md)
 
-[Docker](/installation/docker.md)
+[Docker](installation/docker.md)
 
-[Upgrading from a previous version](/installation/upgrading.md)
+[Upgrading from a previous version](installation/upgrading.md)
 
 _____________________________

--- a/src/installation/build_exec_win.md
+++ b/src/installation/build_exec_win.md
@@ -1,6 +1,6 @@
 # Build executable binaries natively for Windows
 
-Before proceeding, ensure that the [hardware](/getting-started/hw-requirements.md) and [software](/getting-started/sw-requirements.md) requirements are met.
+Before proceeding, ensure that the [hardware](../getting-started/hw-requirements.md) and [software](../getting-started/sw-requirements.md) requirements are met.
 
 
 ## Installing Chocolatey
@@ -134,4 +134,4 @@ or from any place use the full address of the executable:
 start C:\Users\username\AppData\Local\erigon.exe
 ```
 
-See [basic usage](/basic-usage.md) documentation on available options and flags to customize your Erigon experience.
+See [basic usage](../basic-usage.md) documentation on available options and flags to customize your Erigon experience.

--- a/src/installation/docker.md
+++ b/src/installation/docker.md
@@ -39,7 +39,7 @@ docker images
 docker run -it <image_id> --v
 ```
 
-If you want to start Erigon add the options according to the [basic usage](/basic-usage.md) page or the advanced customization page. For example:
+If you want to start Erigon add the options according to the [basic usage](../basic-usage.md) page or the advanced customization page. For example:
 
 ```bash
 docker run -it 36f25992dd1a --chain=holesky --prune.mode=minimal

--- a/src/installation/linux.md
+++ b/src/installation/linux.md
@@ -3,8 +3,8 @@
 
 There are 3 options for running Erigon 3, listed from easiest to most difficult installation:
 
--   [Use pre-built binaries](/installation/prebuilt.md): Download and run the latest stable release of Erigon. This is the easiest option and requires no additional dependencies.
+-   [Use pre-built binaries](prebuilt.md): Download and run the latest stable release of Erigon. This is the easiest option and requires no additional dependencies.
     
--   [Use Docker](/installation/docker.md): Run Erigon in a Docker container for isolation from the host system. This avoids dependencies but requires installing Docker.
+-   [Use Docker](docker.md): Run Erigon in a Docker container for isolation from the host system. This avoids dependencies but requires installing Docker.
 
--  [Build Erigon from source](/installation/build.md): Build the Erigon source code directly on your system. This is the most complex option and requires a working Go environment.
+-  [Build Erigon from source](build.md): Build the Erigon source code directly on your system. This is the most complex option and requires a working Go environment.

--- a/src/installation/windows.md
+++ b/src/installation/windows.md
@@ -3,8 +3,8 @@
 
 There are 3 options for running Erigon 3 on Windows, listed from easiest to most difficult installation:
 
--   [Use Docker](/installation/docker.md): Run Erigon in a Docker container for isolation from the host Windows system. This avoids dependencies on Windows but requires installing Docker.
+-   [Use Docker](docker.md): Run Erigon in a Docker container for isolation from the host Windows system. This avoids dependencies on Windows but requires installing Docker.
     
--   [Build executable binaries natively for Windows](/installation/build_exec_win.md): Use the pre-built Windows executables that can be natively run on Windows without any emulation or containers required.
+-   [Build executable binaries natively for Windows](build_exec_win.md): Use the pre-built Windows executables that can be natively run on Windows without any emulation or containers required.
 
--   [Use Windows Subsystem for Linux (WSL)](/installation/wsl.md): Install the Windows Subsystem for Linux (WSL) to create a Linux environment within Windows. Erigon can then be installed in WSL by following the Linux installation instructions. This provides compatibility with Linux builds but involves more setup overhead.
+-   [Use Windows Subsystem for Linux (WSL)](wsl.md): Install the Windows Subsystem for Linux (WSL) to create a Linux environment within Windows. Erigon can then be installed in WSL by following the Linux installation instructions. This provides compatibility with Linux builds but involves more setup overhead.

--- a/src/installation/wsl.md
+++ b/src/installation/wsl.md
@@ -12,7 +12,7 @@ WSL Version 2 is the only version supported.
 
 </div>
 
-Under this option you can build Erigon as you would on a regular Linux distribution (see detailed instructions [here](/installation/linux.md)).
+Under this option you can build Erigon as you would on a regular Linux distribution (see detailed instructions [here](linux.md)).
 
 You can also point your data to any of the mounted Windows partitions ( e.g. `/mnt/c/[...]`, `/mnt/d/[...]` etc..) but be aware that performance will be affected: this is due to the fact that these mount points use `DrvFS`, which is a network file system, and additionally MDBX locks the db for exclusive access, meaning that only one process at a time can access the data.
 

--- a/src/nodes/eth_extcl.md
+++ b/src/nodes/eth_extcl.md
@@ -23,7 +23,7 @@ Both [Prysm](#erigon-with-prysm-as-the-external-cl) and [Lighthouse](#erigon-wit
 
 3. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
 
-4. Prysm must point to the [JWT secret](/advanced/jwt.md) automatically created by Erigon in the `--datadir` directory. 
+4. Prysm must point to the [JWT secret](../advanced/jwt.md) automatically created by Erigon in the `--datadir` directory. 
 
     ```bash
     ./prysm.sh beacon-chain \
@@ -48,7 +48,7 @@ Both [Prysm](#erigon-with-prysm-as-the-external-cl) and [Lighthouse](#erigon-wit
 
 4. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
 
-5. Lighthouse must point to the [JWT secret](/advanced/jwt.md) automatically created by Erigon in the `--datadir` directory.
+5. Lighthouse must point to the [JWT secret](../advanced/jwt.md) automatically created by Erigon in the `--datadir` directory.
 
     ```bash
     lighthouse bn \

--- a/src/nodes/ethereum.md
+++ b/src/nodes/ethereum.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- Check the [hardware](/getting-started/hw-requirements.md) prerequisites;
-- Check which [type of node](/basic/node.md) you want to run and the [disk space](/basic/disk-space.md) required.
+- Check the [hardware](../getting-started/hw-requirements.md) prerequisites;
+- Check which [type of node](../basic/node.md) you want to run and the [disk space](../basic/disk-space.md) required.
 
 ## Install Erigon​
 
 To set up Erigon quickly, we recommend the following:
-- For Linux and MacOS users, use our [pre-built binaries](/installation/prebuilt.md);
-- For Windows users, [build executable binaries natively](/installation/build_exec_win.md).
+- For Linux and MacOS users, use our [pre-built binaries](../installation/prebuilt.md);
+- For Windows users, [build executable binaries natively](../installation/build_exec_win.md).
 
 # Start Erigon​
 
@@ -34,16 +34,16 @@ erigon \
 ### Flags explanation
 
 - `--datadir=<your_data_dir>` to store Erigon files in a non-default location. Default data directory is `./home/user/.local/share/erigon`.
-- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](/basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
-- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](/basic/wallet.md).
+- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](../basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
+- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](../basic/wallet.md).
 - `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set.
 - Default chain is `--chain=mainnet` for Ethereum mainnet. Use the flag `--chain=holesky` for Holesky testnet, `--chain=sepolia` for Sepolia testnet or `--chain=hoodi` for Hoodi testnet.
 
 To stop your Erigon node you can use the `CTRL+C` command.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking.md) and/or run a [Ethereum node with an external Consensus Layer](/nodes/eth_extcl.md).
+When you get familiar with running Erigon from CLI you may also consider [staking](../staking.md) and/or run a [Ethereum node with an external Consensus Layer](eth_extcl.md).
 
-Additional flags can be added to [configure](/advanced/configuring.md) Erigon with several [options](/advanced/options.md). 
+Additional flags can be added to [configure](../advanced/configuring.md) Erigon with several [options](../advanced/options.md). 
 
 
 

--- a/src/nodes/gno_extcl.md
+++ b/src/nodes/gno_extcl.md
@@ -29,7 +29,7 @@ Alternatively, you can also run a Ethereum node as an Execution Layer (EL) and c
 
 4. To communicate with Erigon, the execution endpoint must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
 
-5. Lighthouse must point to the [JWT secret](/advanced/jwt.md) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
+5. Lighthouse must point to the [JWT secret](../advanced/jwt.md) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
 
         lighthouse \
         --network gnosis beacon_node \

--- a/src/nodes/gnosis.md
+++ b/src/nodes/gnosis.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- Check the [hardware](/getting-started/hw-requirements.md) prerequisites;
-- Check which [type of node](/basic/node.md) you want to run and the [disk space](/basic/disk-space.md) required.
+- Check the [hardware](../getting-started/hw-requirements.md) prerequisites;
+- Check which [type of node](../basic/node.md) you want to run and the [disk space](../basic/disk-space.md) required.
 
 ## Install Erigon​
 
 To set up Erigon quickly, we recommend the following:
-- For Linux and MacOS users, use our [pre-built binaries](/installation/prebuilt.md);
-- For Windows users, [build executable binaries natively](/installation/build_exec_win.md).
+- For Linux and MacOS users, use our [pre-built binaries](../installation/prebuilt.md);
+- For Windows users, [build executable binaries natively](../installation/build_exec_win.md).
 
 # Start Erigon​
 
@@ -37,12 +37,12 @@ erigon \
 
 - `--chain=gnosis` specifies the Gnosis Chain network, use `--chain=chiado` for Chiado testnet.
 - `--datadir=<your_data_dir>` to store Erigon files in a non-default location. Default data directory is `./home/user/.local/share/erigon`.
-- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](/basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
-- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](/basic/wallet.md).
+- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](../basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
+- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](../basic/wallet.md).
 - `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set.
 
 To stop your Erigon node you can use the `CTRL+C` command.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking.md) and/or run a [Gnosis chain node with an external Consensus Layer](/nodes/gno_extcl.md).
+When you get familiar with running Erigon from CLI you may also consider [staking](../staking.md) and/or run a [Gnosis chain node with an external Consensus Layer](gno_extcl.md).
 
-Additional flags can be added to [configure](/advanced/configuring.md) Erigon with several [options](/advanced/options.md).
+Additional flags can be added to [configure](../advanced/configuring.md) Erigon with several [options](../advanced/options.md).

--- a/src/nodes/polygon.md
+++ b/src/nodes/polygon.md
@@ -2,14 +2,14 @@
 
 ## Prerequisites
 
-- Check the [hardware](/getting-started/hw-requirements.md) prerequisites;
-- Check which [type of node](/basic/node.md) you want to run and the [disk space](/basic/disk-space.md) required.
+- Check the [hardware](../getting-started/hw-requirements.md) prerequisites;
+- Check which [type of node](../basic/node.md) you want to run and the [disk space](../basic/disk-space.md) required.
 
 ## Install Erigon​
 
 To set up Erigon quickly, we recommend the following:
-- For Linux and MacOS users, use our [pre-built binaries](/installation/prebuilt.md);
-- For Windows users, [build executable binaries natively](/installation/build_exec_win.md).
+- For Linux and MacOS users, use our [pre-built binaries](../installation/prebuilt.md);
+- For Windows users, [build executable binaries natively](../installation/build_exec_win.md).
 
 # Start Erigon
 
@@ -38,11 +38,11 @@ erigon \
 
 - `--chain=bor-mainnet` and `--bor.heimdall=https://heimdall-api.polygon.technologyspecifies` specify respctevely the Polygon mainnet and the API endpoint for the Heimdall network; to use Amoy tesnet replace with flags `--chain=amoy --bor.heimdall=https://heimdall-api-amoy.polygon.technology`.
 - `--datadir=<your_data_dir>` to store Erigon files in a non-default location. Default data directory is `./home/user/.local/share/erigon`.
-- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](/basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
-- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](/basic/wallet.md).
+- Erigon is full node by default, use `--prune.mode=archive` to run a archive node or `--prune.mode=minimal` (EIP-4444). If you want to change [type of node](../basic/node.md) delete the `--datadir` folder content and restart Erigon with the appropriate flags.
+- `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [wallet](../basic/wallet.md).
 - `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set.
 
 
 To stop your Erigon node you can use the `CTRL+C` command.
 
-Several other [configurations](/advanced/configuring.md) and [options](/advanced/options.md) are available.
+Several other [configurations](../advanced/configuring.md) and [options](../advanced/options.md) are available.

--- a/src/staking.md
+++ b/src/staking.md
@@ -4,6 +4,6 @@
 
 Erigon is a comprehensive execution and consensus layer that also supports staking, aka block production, for Ethereum and Gnosis Chain. Both remote miners and Caplin are supported.
 
-- Using a [external consensus client as validator](/advanced/bp-ext.md);
+- Using a [external consensus client as validator](advanced/bp-ext.md);
 
-- Using [Caplin as validator](/advanced/bp-caplin.md).
+- Using [Caplin as validator](advanced/bp-caplin.md).

--- a/src/tools.md
+++ b/src/tools.md
@@ -2,7 +2,7 @@
 
 Erigon offers a range of tools to enhance your experience and provide valuable assistance when:
 
-1. Troubleshooting issues with your local or remote Erigon node using our [Diagnostics Tool](/tools/introduction.md), which helps you identify and resolve problems efficiently.
-2. Exploring the blockchain with [Otterscan](/tools/otterscan.md), a feature-rich EVM block explorer that allows you to browse and analyze blockchain data with ease.
+1. Troubleshooting issues with your local or remote Erigon node using our [Diagnostics Tool](tools/introduction.md), which helps you identify and resolve problems efficiently.
+2. Exploring the blockchain with [Otterscan](tools/otterscan.md), a feature-rich EVM block explorer that allows you to browse and analyze blockchain data with ease.
 
 Both tools are developed internally and are fully supported for our users.

--- a/src/tools/setup.md
+++ b/src/tools/setup.md
@@ -70,7 +70,7 @@ Replace `YOUR_SESSION_PIN` with the 8-digit PIN allocated to your session during
 
 This will attach the Diagnostics Tool to the Erigon node using the provided session PIN. 
 
-See also other [options](/tools/options.md).
+See also other [options](options.md).
 
 ### 4.2 Remote Node
 


### PR DESCRIPTION
- Book.toml: Installed [mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck) plugin in book.toml for automatic checking of links. No more broken links or the pages won't render; defined default colour scheme as "Ayu".
- All other files: all links are now  relative to avoid the situation where everything will seem to work fine when viewed using a web server (e.g. GitHub Pages or `mdbook serve`), but users viewing the book from the file system may encounter broken links.
- Corrected also some broke links.